### PR TITLE
Feat/adding mobula as a data provider

### DIFF
--- a/apps/explorer/lib/explorer/exchange_rates/source.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source.ex
@@ -35,10 +35,9 @@ defmodule Explorer.ExchangeRates.Source do
   @spec fetch_market_data_for_token_addresses([Hash.Address.t()]) ::
           {:ok, %{Hash.Address.t() => %{fiat_value: float() | nil, circulating_market_cap: float() | nil}}}
           | {:error, any}
-  def fetch_market_data_for_token_addresses(address_hashes) do
-    source_url = CoinGecko.source_url(address_hashes)
-    headers = CoinGecko.headers()
-    fetch_exchange_rates_request(CoinGecko, source_url, headers)
+  def fetch_market_data_for_token_addresses(address_hashes, source \\ exchange_rates_source()) do
+    source_url = source.source_url(address_hashes)
+    fetch_exchange_rates_request(source, source_url, source.headers())
   end
 
   @spec fetch_token_hashes_with_market_data :: {:ok, [String.t()]} | {:error, any}

--- a/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
@@ -147,7 +147,7 @@ defmodule Explorer.ExchangeRates.Source.Mobula do
      config(:base_url) || "https://api.mobula.io/api/1"
   end
 
-  defp get_btc_price(currency \\ "usd") do
+  defp get_btc_price() do
     url = "#{base_url()}/market/data?asset=Bitcoin"
 
     case Source.http_request(url, headers()) do

--- a/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
@@ -81,7 +81,7 @@ defmodule Explorer.ExchangeRates.Source.Mobula do
   def source_url(token_addresses) when is_list(token_addresses) do
     joined_addresses = token_addresses |> Enum.map_join(",", &to_string/1)
 
-    "#{base_url()}/market/multi-data?blockchains=XDAI&assets=#{joined_addresses}"
+    "#{base_url()}/market/multi-data?blockchains=#{chain()}&assets=#{joined_addresses}"
   end
 
   @impl Source
@@ -114,10 +114,6 @@ defmodule Explorer.ExchangeRates.Source.Mobula do
     config(:api_key) || nil
   end
 
-  def coin_id do
-    symbol = String.downcase(Explorer.coin())
-  end
-
   defp get_current_price(market_data) do
     if market_data["price"] do
       to_decimal(market_data["price"])
@@ -144,7 +140,7 @@ defmodule Explorer.ExchangeRates.Source.Mobula do
   end
 
   defp chain do
-    config(:platform) || "ethereum"
+    config(:chain) || "ethereum"
   end
 
   defp base_url do

--- a/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
@@ -99,17 +99,6 @@ defmodule Explorer.ExchangeRates.Source.Mobula do
     end
   end
 
-  @doc """
-  Converts date time string into DateTime object formatted as date
-  """
-  @spec date(String.t()) :: Date.t()
-  def date(date_time_string) do
-    with {:ok, datetime, _} <- DateTime.from_iso8601(date_time_string) do
-      datetime
-      |> DateTime.to_date()
-    end
-  end
-
   defp api_key do
     config(:api_key) || nil
   end

--- a/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
@@ -90,6 +90,24 @@ defmodule Explorer.ExchangeRates.Source.Mobula do
     "#{base_url()}/market/data&asset=#{symbol}"
   end
 
+  def history_source_url do
+    id = config(:secondary_coin_id)
+
+    if id, do: "#{base_url()}/market/history?asset=#{id}", else: "#{base_url()}/market/history?asset=#{Explorer.coin()}"
+  end
+
+  @spec history_url(non_neg_integer()) :: String.t()
+  def history_url(previous_days) do
+
+    now = DateTime.utc_now()
+    date_days_ago = DateTime.add(now, -previous_days, :day)
+    timestamp_ms = DateTime.to_unix(date_days_ago) * 1000
+
+    Logger.info("Fetching price history from Mobula: #{history_source_url()} for the last #{previous_days} days. Timestamp: #{timestamp_ms} ms. Now: #{DateTime.to_unix(now)} ms. Date days ago: #{DateTime.to_unix(date_days_ago)} ms.")
+
+    "#{history_source_url()}&from=#{timestamp_ms}"
+  end
+
   @impl Source
   def headers do
     if api_key() do

--- a/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
@@ -1,0 +1,147 @@
+defmodule Explorer.ExchangeRates.Source.Mobula do
+  @moduledoc """
+  Adapter for fetching exchange rates from https://mobula.io
+  """
+
+  alias Explorer.{Chain, Helper}
+  alias Explorer.ExchangeRates.{Source, Token}
+
+  import Source, only: [to_decimal: 1]
+
+  @behaviour Source
+
+  @impl Source
+  def format_data(%{} = market_data_for_tokens) do
+
+    market_data = market_data_for_tokens["data"]
+
+    current_price = market_data["price"]
+    image_url = market_data["logo"]
+
+    id = String.downcase(market_data["symbol"])
+
+    btc_value =
+      if Application.get_env(:explorer, Explorer.ExchangeRates)[:fetch_btc_value], do: get_btc_value(id, market_data)
+
+    circulating_supply_data = market_data && market_data["circulating_supply"]
+    total_supply_data = market_data && market_data["total_supply"]
+    market_cap_data_usd = market_data && market_data["market_cap"]
+    total_volume_data_usd = market_data && market_data["volume"]
+
+    [
+      %Token{
+        available_supply: to_decimal(circulating_supply_data),
+        total_supply: to_decimal(total_supply_data) || to_decimal(circulating_supply_data),
+        btc_value: btc_value,
+        id: id,
+        last_updated: nil,
+        market_cap_usd: to_decimal(market_cap_data_usd),
+        tvl_usd: nil,
+        name: market_data["name"],
+        symbol: String.upcase(market_data["symbol"]),
+        usd_value: current_price,
+        volume_24h_usd: to_decimal(total_volume_data_usd),
+        image_url: image_url
+      }
+    ]
+  end
+
+  @impl Source
+  def format_data(_), do: []
+
+  @impl Source
+  def source_url do
+   "#{base_url()}/search?input=#{coin_id()}"
+  end
+
+  @impl Source
+  def source_url(token_addresses) when is_list(token_addresses) do
+    joined_addresses = token_addresses |> Enum.map_join(",", &to_string/1)
+
+    "#{base_url()}/market/multi-data?blockchains=#{chain()}&assets=#{joined_addresses}"
+  end
+
+  @impl Source
+  def headers do
+    if api_key() do
+      [{"Authorization", "#{api_key()}"}]
+    else
+      []
+    end
+  end
+
+  @doc """
+  Converts date time string into DateTime object formatted as date
+  """
+  @spec date(String.t()) :: Date.t()
+  def date(date_time_string) do
+    with {:ok, datetime, _} <- DateTime.from_iso8601(date_time_string) do
+      datetime
+      |> DateTime.to_date()
+    end
+  end
+
+  defp api_key do
+    config(:api_key) || nil
+  end
+
+  def coin_id do
+    symbol = String.downcase(Explorer.coin())
+  end
+
+  defp get_current_price(market_data) do
+    if market_data["price"] do
+      to_decimal(market_data["price"])
+    else
+      1
+    end
+  end
+
+  defp get_btc_value(id, market_data) do
+    case get_btc_price() do
+      {:ok, price} ->
+        btc_price = to_decimal(price)
+        current_price = get_current_price(market_data)
+
+        if id != "btc" && current_price && btc_price do
+          Decimal.div(current_price, btc_price)
+        else
+          1
+        end
+
+      _ ->
+        1
+    end
+  end
+
+  defp chain do
+    config(:platform) || "ethereum"
+  end
+
+  defp base_url do
+     config(:base_url) || "https://api.mobula.io/api/1"
+  end
+
+  defp get_btc_price() do
+    url = "#{base_url()}/market/data?asset=Bitcoin"
+
+    case Source.http_request(url, headers()) do
+      {:ok, data} = resp ->
+        if is_map(data) do
+          current_price = data['price']
+
+          {:ok, current_price}
+        else
+          resp
+        end
+
+      resp ->
+        resp
+    end
+  end
+
+  @spec config(atom()) :: term
+  defp config(key) do
+    Application.get_env(:explorer, __MODULE__, [])[key]
+  end
+end

--- a/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
+++ b/apps/explorer/lib/explorer/exchange_rates/source/mobula.ex
@@ -147,7 +147,7 @@ defmodule Explorer.ExchangeRates.Source.Mobula do
   end
 
   defp chain do
-    config(:chain) || "ethereum"
+    config(:chain_id) || "ethereum"
   end
 
   defp base_url do

--- a/apps/explorer/lib/explorer/market/history/source/price/mobula.ex
+++ b/apps/explorer/lib/explorer/market/history/source/price/mobula.ex
@@ -1,0 +1,49 @@
+defmodule Explorer.Market.History.Source.Price.Mobula do
+  @moduledoc """
+  Adapter for fetching current market from Mobula.
+  """
+
+  require Logger
+  alias Explorer.ExchangeRates.Source
+  alias Explorer.ExchangeRates.Source.Mobula, as: ExchangeRatesSourceMobula
+  alias Explorer.Market.History.Source.Price, as: SourcePrice
+  alias Explorer.Market.History.Source.Price.CryptoCompare
+
+  @behaviour SourcePrice
+
+  @impl SourcePrice
+  def fetch_price_history(previous_days, secondary_coin? \\ false) do
+    url = ExchangeRatesSourceMobula.history_url(previous_days)
+
+    case Source.http_request(url, ExchangeRatesSourceMobula.headers()) do
+      {:ok, data} ->
+
+        result =
+          data
+          |> format_data(secondary_coin?)
+
+        {:ok, result}
+
+      _ ->
+        :error
+    end
+  end
+
+  @spec format_data(term(), boolean()) :: SourcePrice.record() | nil
+  defp format_data(nil, _), do: nil
+
+  defp format_data(data, secondary_coin?) do
+    prices = data["data"]["price_history"]
+
+    for [date, price] <- prices do
+      date = Decimal.to_integer(Decimal.round(Decimal.from_float(date / 1000)))
+
+      %{
+        closing_price: Decimal.new(to_string(price)),
+        date: CryptoCompare.date(date),
+        opening_price: Decimal.new(to_string(price)),
+        secondary_coin: secondary_coin?
+      }
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

Integrating Mobula as a data provider significantly enhances Blockscout's market data capabilities, offering users access to a broader range of accurate and real-time data. Mobula's comprehensive dataset supports improved transparency and user experience.

## Changelog

### Enhancements
- Added Mobula as a data provider for exchanges rates.
- Improved market data accuracy and refresh rates with Mobula's real-time data feeds.
- Expanded data offering to include new tokens and pairs tracked by Mobula.
